### PR TITLE
Исправлен синтаксис zenbadge

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@
 КонецПроцедуры
 ```
 
-[![ZenHub] (https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)] (https://zenhub.io)
+[![ZenHub](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)] (https://zenhub.io)


### PR DESCRIPTION
Пробел после `]` может ломать отображение картинки в различных парсерах (например, в Atom)
